### PR TITLE
Fix missing export for reset password email

### DIFF
--- a/frontend/src/services/database.ts
+++ b/frontend/src/services/database.ts
@@ -61,6 +61,11 @@ export async function createSignupInvitation(facilityId: string, email: string, 
 export async function sendInvitationEmail(invitation: SignupInvitation, facilityName: string) { return rpcCall<boolean>('sendInvitationEmail', [invitation, facilityName]) }
 export async function sendInviteByEmail(params: { email: string; role?: 'OM' | 'POA' | 'Resident'; facilityId?: string; residentId?: string; name?: string; redirectTo?: string }) { return rpcCall<boolean>('sendInviteByEmail', [params]) }
 
+// Sends a role-based reset password email using backend RPC
+export async function sendRoleBasedResetPasswordEmail(params: { email: string; role: 'OM' | 'POA' | 'Resident' | 'Vendor'; siteUrl?: string }) {
+  return rpcCall<boolean>('sendRoleBasedResetPasswordEmail', [params])
+}
+
 export async function getPreAuthDebitsByResident(residentId: string, month?: string) { return rpcCall<PreAuthDebit[]>('getPreAuthDebitsByResident', [residentId, month]) }
 export async function getPreAuthDebitsByFacility(facilityId: string, month?: string) { return rpcCall<PreAuthDebit[]>('getPreAuthDebitsByFacility', [facilityId, month]) }
 export async function createPreAuthDebit(preAuthDebitData: Omit<PreAuthDebit, 'id' | 'createdAt'>) { return rpcCall<PreAuthDebit>('createPreAuthDebit', [preAuthDebitData]) }


### PR DESCRIPTION
Add `sendRoleBasedResetPasswordEmail` export to `frontend/src/services/database.ts` to resolve a `SyntaxError` when importing.

---
<a href="https://cursor.com/background-agent?bcId=bc-b9dc4db1-6cf6-48fa-87ba-825bb7f0d7b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b9dc4db1-6cf6-48fa-87ba-825bb7f0d7b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

