### PR TITLE
Handle login rpc error

### DIFF
--- a/backend/config/supabase.ts
+++ b/backend/config/supabase.ts
@@ -1,15 +1,18 @@
 import { createClient } from '@supabase/supabase-js';
-import { SUPABASE_SERVICE_ROLE_KEY, SUPABASE_URL } from './env.js';
+import { SUPABASE_SERVICE_ROLE_KEY, SUPABASE_URL, SUPABASE_ANON_KEY } from './env.js';
 
-if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
-  // Defer throwing until a DB function is called; export a lazy getter
-}
+// Eagerly create clients when credentials are present; else keep null and throw on access
+export const supabaseAdmin = (SUPABASE_URL && SUPABASE_SERVICE_ROLE_KEY)
+  ? createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, { auth: { persistSession: false, autoRefreshToken: false } })
+  : null as any;
+
+export const supabase = (SUPABASE_URL && SUPABASE_ANON_KEY)
+  ? createClient(SUPABASE_URL, SUPABASE_ANON_KEY, { auth: { persistSession: false, autoRefreshToken: false } })
+  : null as any;
 
 export function getSupabaseAdmin() {
   if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
     throw new Error('Supabase credentials are not set. Please set SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY');
   }
-  return createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
-    auth: { persistSession: false, autoRefreshToken: false }
-  });
+  return supabaseAdmin as ReturnType<typeof createClient>;
 }

--- a/backend/services/app/database.ts
+++ b/backend/services/app/database.ts
@@ -1,4 +1,4 @@
-import { supabase, getSupabaseAdmin, supabaseAdmin } from '../config/supabase'
+import { supabase, getSupabaseAdmin, supabaseAdmin } from '../../config/supabase'
 import { User, Facility, Resident, Transaction, ServiceBatch, ServiceBatchItem, PreAuthDebit, MonthlyPreAuthList, MonthlyCashBoxHistory, SignupInvitation } from '../types'
 import { Invoice, InvoiceItem } from '../types'
 import { Database } from '../types/database'


### PR DESCRIPTION
Export Supabase clients directly and fix their import path in the database service to resolve 500 errors during sign-in.

The previous setup deferred Supabase client initialization, causing `signInUser` to throw 500 errors if credentials were not set or the client was accessed before being properly initialized. Directly exporting the clients (conditionally) and correcting the import path ensures `signInUser` can correctly access them.

---
<a href="https://cursor.com/background-agent?bcId=bc-b7cba46d-0231-41c9-a74c-3cac68a09872"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b7cba46d-0231-41c9-a74c-3cac68a09872"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

