### PR TITLE
Fix missing tsconfig path

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch server/index.ts",
-    "build": "tsc -p backend/tsconfig.json",
+    "build": "tsc -p tsconfig.json",
     "start": "node dist/server/index.js"
   },
   "dependencies": {


### PR DESCRIPTION
Update backend build script to use the correct `tsconfig.json` path, resolving TS5058 error.

---
<a href="https://cursor.com/background-agent?bcId=bc-d879fc70-e389-49d5-a477-7547b76c7cbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d879fc70-e389-49d5-a477-7547b76c7cbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

