### PR TITLE
Fix missing supabase config import

### DIFF
--- a/backend/services/app/cashbox-database.ts
+++ b/backend/services/app/cashbox-database.ts
@@ -1,4 +1,4 @@
-import { supabase } from '../../config/supabase';
+import { supabase } from '../../config/supabase.js';
 // Note: backend DB types are provided via generics on the Supabase client; remove unused imports
 // DB generics inferred from configured client; no explicit import needed
 // Cash Box Types

--- a/backend/services/app/database.ts
+++ b/backend/services/app/database.ts
@@ -1,4 +1,4 @@
-import { supabase, getSupabaseAdmin, supabaseAdmin } from '../../config/supabase'
+import { supabase, getSupabaseAdmin, supabaseAdmin } from '../../config/supabase.js'
 import { User, Facility, Resident, Transaction, ServiceBatch, ServiceBatchItem, PreAuthDebit, MonthlyPreAuthList, SignupInvitation } from '../../types/models'
 type InvoiceItem = { id: string; invoiceId: string; residentId: string; amount: number; description: string; createdAt: string; updatedAt?: string }
 type Invoice = { id: string; facilityId: string; vendorUserId: string; status: 'open' | 'submitted' | 'paid'; omNotes?: string; createdAt: string; updatedAt?: string; submittedAt?: string; paidAt?: string; paidBy?: string; items: InvoiceItem[]; invoice_no?: number | string; vendorName?: string; vendorAddress?: string; vendorEmail?: string; invoiceDate?: string }

--- a/backend/services/app/paypal.ts
+++ b/backend/services/app/paypal.ts
@@ -1,4 +1,4 @@
-import { supabase } from '../../config/supabase';
+import { supabase } from '../../config/supabase.js';
 
 export interface PayPalConfig {
   clientId: string;


### PR DESCRIPTION
Add `.js` extension to `supabase` imports to fix `ERR_MODULE_NOT_FOUND` in the transpiled `dist` build.

Node ESM requires explicit file extensions for module resolution in the transpiled output, which was causing the runtime error.

---
<a href="https://cursor.com/background-agent?bcId=bc-d977c1fe-366d-4b95-b479-189217e13403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d977c1fe-366d-4b95-b479-189217e13403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

