### PR TITLE
Fix cors policy on server response

### DIFF
--- a/backend/config/env.ts
+++ b/backend/config/env.ts
@@ -16,6 +16,12 @@ export const PORT = Number(getEnv('PORT', '4000'));
 export const FRONTEND_URL = getEnv('FRONTEND_URL', 'http://localhost:5173');
 export const BACKEND_URL = getEnv('BACKEND_URL', 'https://trust-3.onrender.com');
 
+// Optional: comma-separated additional allowed origins for CORS
+export const CORS_ORIGINS: string[] = (process.env.CORS_ORIGINS || '')
+  .split(',')
+  .map((s: string) => s.trim())
+  .filter(Boolean);
+
 // Optional at startup; validated by respective modules when used
 export const SUPABASE_URL = process.env.SUPABASE_URL;
 export const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;


### PR DESCRIPTION
Implement dynamic CORS origin allowlist to support multiple frontend development environments.

The previous CORS configuration only allowed a single `FRONTEND_URL`. This change introduces a `CORS_ORIGINS` environment variable, allowing a comma-separated list of additional origins to be whitelisted. This resolves CORS errors when the frontend is hosted on dynamic URLs (e.g., webcontainers) that differ from the primary `FRONTEND_URL`.

---
<a href="https://cursor.com/background-agent?bcId=bc-9fee7105-fccc-47fb-8417-1977c2b0a9b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9fee7105-fccc-47fb-8417-1977c2b0a9b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

