### PR TITLE
Debug standalone frontend netlify deployment

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,18 @@
+[build]
+  base = "frontend"
+  command = "npm ci && npm run build"
+  publish = "dist"
+
+# Ensure SPA routing works (fallback to index.html). Vite will copy public/_redirects, but we add safety here.
+[[redirects]]
+  from = "/api/*"
+  to = "/.netlify/functions/:splat"
+  status = 200
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200
+
+[build.environment]
+  NODE_VERSION = "18"


### PR DESCRIPTION
Add `netlify.toml` to configure Netlify for standalone frontend deployment and fix build failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-6d2e0f18-901d-48aa-9423-bb6e5c634413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6d2e0f18-901d-48aa-9423-bb6e5c634413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

