### PR TITLE
Debug missing supabase key error

### DIFF
--- a/frontend/src/config/supabase.ts
+++ b/frontend/src/config/supabase.ts
@@ -4,6 +4,14 @@ import type { Database } from '../types/database'
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string
 
+if (!supabaseUrl) {
+  throw new Error('VITE_SUPABASE_URL is missing. Set it in Netlify env vars.');
+}
+
+if (!supabaseAnonKey) {
+  throw new Error('VITE_SUPABASE_ANON_KEY is missing. Set it in Netlify env vars.');
+}
+
 export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey, {
   auth: {
     autoRefreshToken: true,

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,12 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+	readonly VITE_SUPABASE_URL: string;
+	readonly VITE_SUPABASE_ANON_KEY: string;
+	// add other public envs here if needed
+}
+
+interface ImportMeta {
+	readonly env: ImportMetaEnv;
+}
+


### PR DESCRIPTION
Add explicit runtime checks for Supabase environment variables and their type declarations.

This provides clearer error messages when `VITE_SUPABASE_URL` or `VITE_SUPABASE_ANON_KEY` are missing in the Netlify deployment environment and resolves TypeScript errors related to `import.meta.env` usage.

---
<a href="https://cursor.com/background-agent?bcId=bc-6aa51fb8-842a-40e5-b3a0-25cbc99747a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6aa51fb8-842a-40e5-b3a0-25cbc99747a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

