### PR TITLE
Update cors to allow trust1.netlify.app

### DIFF
--- a/backend/config/env.ts
+++ b/backend/config/env.ts
@@ -13,7 +13,7 @@ function getEnv(name: string, fallback?: string): string {
 
 export const NODE_ENV = getEnv('NODE_ENV', 'development');
 export const PORT = Number(getEnv('PORT', '4000'));
-export const FRONTEND_URL = getEnv('FRONTEND_URL', 'https://zp1v56uxy8rdx5ypatb0ockcb9tr6a-oci3--5173--96435430.local-credentialless.webcontainer-api.io');
+export const FRONTEND_URL = getEnv('FRONTEND_URL', 'https://trust1.netlify.app');
 export const BACKEND_URL = getEnv('BACKEND_URL', 'https://trust-3.onrender.com');
 
 // Optional at startup; validated by respective modules when used

--- a/backend/server/index.ts
+++ b/backend/server/index.ts
@@ -8,7 +8,7 @@ import * as appPaypal from '../services/app/paypal.js';
 
 const app = express();
 
-app.use(cors({ origin: FRONTEND_URL, credentials: true }));
+app.use(cors({ origin: [FRONTEND_URL, 'https://trust1.netlify.app'], credentials: true }));
 app.use(express.json());
 
 app.get('/api/health', (_req, res) => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -9,9 +9,12 @@ dotenv.config();
 const app = express();
 const port = process.env.PORT || 3001;
 
-const allowedOrigin = process.env.FRONTEND_URL || 'https://zp1v56uxy8rdx5ypatb0ockcb9tr6a-oci3--5173--96435430.local-credentialless.webcontainer-api.io';
+const allowedOrigins = [
+  'https://trust1.netlify.app',
+  process.env.FRONTEND_URL || 'https://zp1v56uxy8rdx5ypatb0ockcb9tr6a-oci3--5173--96435430.local-credentialless.webcontainer-api.io',
+].filter(Boolean);
 app.use(cors({
-  origin: allowedOrigin,
+  origin: allowedOrigins,
   credentials: true,
 }));
 app.use(express.json());


### PR DESCRIPTION
Update CORS policies to allow the frontend at `https://trust1.netlify.app`.

---
<a href="https://cursor.com/background-agent?bcId=bc-ff0a3d77-66a1-4836-a9b8-4bc2d906d2c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ff0a3d77-66a1-4836-a9b8-4bc2d906d2c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

