### PR TITLE
Fix POA dashboard backend data loading

### DIFF
--- a/backend/server/index.ts
+++ b/backend/server/index.ts
@@ -77,6 +77,15 @@ const rpcAllowlist: Record<string, any> = {
   updateServiceBatchItem: appDb.updateServiceBatchItem,
   postServiceBatch: appDb.postServiceBatch,
   deleteServiceBatch: appDb.deleteServiceBatch,
+  // pre-authorization debits
+  getPreAuthDebitsByResident: appDb.getPreAuthDebitsByResident,
+  getPreAuthDebitsByFacility: appDb.getPreAuthDebitsByFacility,
+  createPreAuthDebit: appDb.createPreAuthDebit,
+  updatePreAuthDebit: appDb.updatePreAuthDebit,
+  createMonthlyPreAuthList: appDb.createMonthlyPreAuthList,
+  getMonthlyPreAuthList: appDb.getMonthlyPreAuthList,
+  getFacilityMonthlyPreAuthLists: appDb.getFacilityMonthlyPreAuthLists,
+  closeMonthlyPreAuthList: appDb.closeMonthlyPreAuthList,
   createDepositBatchDb: appDb.createDepositBatchDb,
   getDepositBatchesByFacilityDb: appDb.getDepositBatchesByFacilityDb,
   getDepositBatchByIdDb: appDb.getDepositBatchByIdDb,
@@ -104,6 +113,12 @@ const rpcAllowlist: Record<string, any> = {
   sendInvitationEmail: appDb.sendInvitationEmail,
   sendInviteByEmail: appDb.sendInviteByEmail,
   provisionUser: appDb.provisionUser,
+  // OM admin helpers
+  createOfficeManagerUser: appDb.createOfficeManagerUser,
+  getOmUsers: appDb.getOmUsers,
+  clearFacilityForUser: appDb.clearFacilityForUser,
+  // auth email helpers
+  sendRoleBasedResetPasswordEmail: appDb.sendRoleBasedResetPasswordEmail,
   // cashbox
   updateCashBoxBalanceWithTransaction: appDb.updateCashBoxBalanceWithTransaction,
   resetCashBoxToMonthly: appDb.resetCashBoxToMonthly,


### PR DESCRIPTION
Add missing RPC methods to the server allowlist to resolve "Unknown RPC method" errors for the POA Dashboard.

The POA Dashboard was encountering 404 errors and "Unknown RPC method" errors because several RPC calls it makes were not registered in the backend's `rpcAllowlist`. This PR adds the necessary pre-authorization debit, monthly list, OM admin, and auth helper methods to the allowlist, enabling the dashboard to function correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-24f1506c-3969-4e32-9b90-4ff66f8271b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-24f1506c-3969-4e32-9b90-4ff66f8271b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

