### PR TITLE
Fix landing page styling on netlify

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,10 +1,11 @@
+@import './landing.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 
 /* Landing page global styles */
-@import './landing.css';
 
 @layer base {
   /* Improve default contrast for form controls */


### PR DESCRIPTION
Move `@import './landing.css'` to the top of `frontend/src/index.css` to resolve a Vite CSS import order error.

---
<a href="https://cursor.com/background-agent?bcId=bc-0682f214-9775-40ea-afa4-bd02043176a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0682f214-9775-40ea-afa4-bd02043176a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

