### PR TITLE
Add miscellaneous service type to dashboards

### DIFF
--- a/backend/services/app/database.ts
+++ b/backend/services/app/database.ts
@@ -1529,7 +1529,8 @@ function getServiceTypeLabel(serviceType: ServiceBatch['serviceType']) {
     footcare: 'Foot Care',
     pharmacy: 'Pharmacy',
     cable: 'Cable TV',
-    wheelchairRepair: 'Wheelchair Repair'
+    wheelchairRepair: 'Wheelchair Repair',
+    miscellaneous: 'Miscellaneous'
   }
   return labels[serviceType]
 }

--- a/backend/types/models.ts
+++ b/backend/types/models.ts
@@ -62,7 +62,7 @@ export interface ServiceBatchItem {
 export interface ServiceBatch {
   id: string;
   facilityId: string;
-  serviceType: 'haircare' | 'footcare' | 'pharmacy' | 'cable' | 'wheelchairRepair';
+  serviceType: 'haircare' | 'footcare' | 'pharmacy' | 'cable' | 'wheelchairRepair' | 'miscellaneous';
   status: 'open' | 'posted';
   createdAt: string;
   postedAt?: string;

--- a/frontend/src/components/BatchTransactionForm.tsx
+++ b/frontend/src/components/BatchTransactionForm.tsx
@@ -164,8 +164,9 @@ export default function BatchTransactionForm({ onClose }: BatchTransactionFormPr
     footcare: 'Foot Care',
     pharmacy: 'Pharmacy',
     cable: 'Cable TV',
-    wheelchairRepair: 'Wheelchair Repair'
-  };
+    wheelchairRepair: 'Wheelchair Repair',
+    miscellaneous: 'Miscellaneous'
+  } as const;
 
   return (
     <>

--- a/frontend/src/components/BatchesPage.tsx
+++ b/frontend/src/components/BatchesPage.tsx
@@ -15,7 +15,7 @@ interface BatchItem {
 }
 
 export default function BatchesPage({ onBack }: BatchesPageProps) {
-  const [selectedService, setSelectedService] = useState<'haircare' | 'footcare' | 'pharmacy' | 'cable' | 'wheelchairRepair'>('haircare');
+  const [selectedService, setSelectedService] = useState<'haircare' | 'footcare' | 'pharmacy' | 'cable' | 'wheelchairRepair' | 'miscellaneous'>('haircare');
   const [batchItems, setBatchItems] = useState<BatchItem[]>([]);
   const [showReceipt, setShowReceipt] = useState(false);
   const [batchResults, setBatchResults] = useState<any[]>([]);
@@ -30,7 +30,8 @@ export default function BatchesPage({ onBack }: BatchesPageProps) {
     footcare: 'Foot Care',
     pharmacy: 'Pharmacy',
     cable: 'Cable TV',
-    wheelchairRepair: 'Wheelchair Repair'
+    wheelchairRepair: 'Wheelchair Repair',
+    miscellaneous: 'Miscellaneous'
   };
 
   const eligibleResidents = residents.filter(r => 

--- a/frontend/src/components/ChatbotWidget.tsx
+++ b/frontend/src/components/ChatbotWidget.tsx
@@ -39,7 +39,7 @@ function BotAvatar() {
 
 export default function ChatbotWidget() {
   const config = useMemo(() => ({
-    initialMessages: [createChatBotMessage('Hi! Ask me about balances, transactions, batches, cash box. Examples: balance in "John Doe" account; recent 5 transactions in "Jane Smith" account; all transactions in haircare batch; online transactions this month; cash box transactions')],
+    initialMessages: [createChatBotMessage('Hi! Ask me about balances, transactions, batches, cash box. Examples: balance in "John Doe" account; recent 5 transactions in "Jane Smith" account; all transactions in haircare or miscellaneous batch; online transactions this month; cash box transactions')],
     botName: 'OM Assistant',
     customComponents: {
       botAvatar: (props: any) => <BotAvatar />,

--- a/frontend/src/components/OMDashboard.tsx
+++ b/frontend/src/components/OMDashboard.tsx
@@ -144,7 +144,8 @@ export default function OMDashboard() {
     footcare: 'Foot Care',
     pharmacy: 'Pharmacy',
     cable: 'Cable TV',
-    wheelchairRepair: 'Wheelchair Repair'
+    wheelchairRepair: 'Wheelchair Repair',
+    miscellaneous: 'Miscellaneous'
   };
 
   const postedServiceBatchesThisMonth = currentFacility
@@ -510,7 +511,7 @@ export default function OMDashboard() {
       ['Posted Date', 'Service', 'Residents', 'Total Amount'],
       serviceBatchesPosted.map(b => [
         b.postedAt ? new Date(b.postedAt).toLocaleDateString() : '',
-        b.serviceType,
+        serviceTypeLabels[b.serviceType] || b.serviceType,
         String(b.items.length),
         `$${b.totalAmount.toFixed(2)}`,
       ]),

--- a/frontend/src/components/OMInvoicesPage.tsx
+++ b/frontend/src/components/OMInvoicesPage.tsx
@@ -351,6 +351,7 @@ export default function OMInvoicesPage() {
                 <option value="footcare">Foot Care</option>
                 <option value="pharmacy">Pharmacy</option>
                 <option value="cable">Cable TV</option>
+                <option value="miscellaneous">Miscellaneous</option>
                 <option value="wheelchairRepair">Wheelchair Repair</option>
               </select>
             </div>

--- a/frontend/src/components/OmChatbot.tsx
+++ b/frontend/src/components/OmChatbot.tsx
@@ -32,7 +32,7 @@ export default function OmChatbot() {
       </div>
       <div className="p-6 space-y-4 max-h-[60vh] overflow-y-auto">
         {messages.length === 0 ? (
-          <div className="text-sm text-gray-600">Try questions like: What is balance in 'John Doe' account? Recent 5 transactions in 'Jane Smith' account. All transactions in haircare batch. Recent online transactions for this month. Recent deposit batch transactions. Recent cash box transactions.</div>
+          <div className="text-sm text-gray-600">Try questions like: What is balance in 'John Doe' account? Recent 5 transactions in 'Jane Smith' account. All transactions in haircare or miscellaneous batch. Recent online transactions for this month. Recent deposit batch transactions. Recent cash box transactions.</div>
         ) : (
           messages.map(m => (
             <div key={m.id} className={`whitespace-pre-wrap ${m.role === 'user' ? 'text-gray-900' : 'text-gray-800'}`}>

--- a/frontend/src/components/POADashboard.tsx
+++ b/frontend/src/components/POADashboard.tsx
@@ -197,7 +197,7 @@ export default function POADashboard() {
                     {Object.entries(linkedResident.serviceAuthorizations || linkedResident.allowedServices).map(([service, authorized]) => 
                       authorized && (
                         <span key={service} className="inline-flex px-1 py-0.5 text-xs bg-green-100 text-green-800 rounded">
-                          {service === 'wheelchairRepair' ? 'Wheelchair' : service.charAt(0).toUpperCase() + service.slice(1)}
+                          {service === 'wheelchairRepair' ? 'Wheelchair' : service === 'miscellaneous' ? 'Miscellaneous' : service.charAt(0).toUpperCase() + service.slice(1)}
                         </span>
                       )
                     )}
@@ -492,7 +492,8 @@ export default function POADashboard() {
                 { key: 'footcare', label: 'Foot Care Services' },
                 { key: 'pharmacy', label: 'Pharmacy Purchases' },
                 { key: 'cable', label: 'Cable TV Services' },
-                { key: 'wheelchairRepair', label: 'Wheelchair Repair' }
+                { key: 'wheelchairRepair', label: 'Wheelchair Repair' },
+                { key: 'miscellaneous', label: 'Miscellaneous' }
               ].map(service => {
                 const isAllowedByFacility = linkedResident?.allowedServices[service.key as keyof typeof linkedResident.allowedServices];
                 const isAuthorized = linkedResident?.serviceAuthorizations?.[service.key as keyof typeof linkedResident.serviceAuthorizations] ?? isAllowedByFacility ?? false;

--- a/frontend/src/components/ResidentForm.tsx
+++ b/frontend/src/components/ResidentForm.tsx
@@ -31,7 +31,8 @@ export default function ResidentForm({ onClose }: ResidentFormProps) {
       footcare: true,
       pharmacy: true,
       cable: true,
-      wheelchairRepair: true
+      wheelchairRepair: true,
+      miscellaneous: false
     }
   });
 const [formError, setFormError] = useState<string | null>(null);
@@ -339,7 +340,8 @@ const [formError, setFormError] = useState<string | null>(null);
                 { key: 'footcare', label: 'Foot Care' },
                 { key: 'pharmacy', label: 'Pharmacy' },
                 { key: 'cable', label: 'Cable TV' },
-                { key: 'wheelchairRepair', label: 'Wheelchair Repair' }
+                { key: 'wheelchairRepair', label: 'Wheelchair Repair' },
+                { key: 'miscellaneous', label: 'Miscellaneous' }
               ].map(service => (
                 <label key={service.key} className="flex items-center space-x-2">
                   <input

--- a/frontend/src/components/ResidentProfile.tsx
+++ b/frontend/src/components/ResidentProfile.tsx
@@ -79,7 +79,8 @@ export default function ResidentProfile({ resident, onClose }: ResidentProfilePr
     { key: 'footcare', label: 'Foot Care' },
     { key: 'pharmacy', label: 'Pharmacy' },
     { key: 'cable', label: 'Cable TV' },
-    { key: 'wheelchairRepair', label: 'Wheelchair Repair' }
+    { key: 'wheelchairRepair', label: 'Wheelchair Repair' },
+    { key: 'miscellaneous', label: 'Miscellaneous' }
   ];
 
   const isManuallyManaged = !resident.linkedUserId;

--- a/frontend/src/components/ServiceBatchHistory.tsx
+++ b/frontend/src/components/ServiceBatchHistory.tsx
@@ -9,7 +9,7 @@ interface ServiceBatchHistoryProps {
   onBack: () => void;
 }
 
-type ServiceType = 'haircare' | 'footcare' | 'pharmacy' | 'cable' | 'wheelchairRepair';
+type ServiceType = 'haircare' | 'footcare' | 'pharmacy' | 'cable' | 'wheelchairRepair' | 'miscellaneous';
 
 export default function ServiceBatchHistory({ onBack }: ServiceBatchHistoryProps) {
   const [selectedService, setSelectedService] = useState<ServiceType | null>(null);
@@ -39,7 +39,8 @@ export default function ServiceBatchHistory({ onBack }: ServiceBatchHistoryProps
     footcare: 'Foot Care',
     pharmacy: 'Pharmacy',
     cable: 'Cable TV',
-    wheelchairRepair: 'Wheelchair Repair'
+    wheelchairRepair: 'Wheelchair Repair',
+    miscellaneous: 'Miscellaneous'
   };
 
   const facilityResidents = currentFacility ? getFacilityResidents(currentFacility.id) : [];
@@ -547,7 +548,8 @@ function BatchDetailsModal({
     footcare: 'Foot Care',
     pharmacy: 'Pharmacy',
     cable: 'Cable TV',
-    wheelchairRepair: 'Wheelchair Repair'
+    wheelchairRepair: 'Wheelchair Repair',
+    miscellaneous: 'Miscellaneous'
   };
 
   return (

--- a/frontend/src/components/TransactionForm.tsx
+++ b/frontend/src/components/TransactionForm.tsx
@@ -198,6 +198,7 @@ export default function TransactionForm({ residentId, initialType = 'credit', on
               {resident?.allowedServices.footcare && <option value="Foot Care Service">Foot Care Service</option>}
               {resident?.allowedServices.pharmacy && <option value="Pharmacy Purchase">Pharmacy Purchase</option>}
               {resident?.allowedServices.cable && <option value="Cable TV Payment">Cable TV Payment</option>}
+              {resident?.allowedServices.miscellaneous && <option value="Miscellaneous Service">Miscellaneous Service</option>}
               {resident?.allowedServices.wheelchairRepair && <option value="Wheelchair Repair">Wheelchair Repair</option>}
               <option value="Personal Care Items">Personal Care Items</option>
               <option value="Clothing">Clothing</option>

--- a/frontend/src/hooks/useOmIntentExecutor.ts
+++ b/frontend/src/hooks/useOmIntentExecutor.ts
@@ -53,12 +53,13 @@ export function useOmIntentExecutor() {
     return fuzzy || null;
   }
 
-  function parseServiceType(text: string): 'haircare' | 'footcare' | 'pharmacy' | 'cable' | 'wheelchairRepair' | null {
+  function parseServiceType(text: string): 'haircare' | 'footcare' | 'pharmacy' | 'cable' | 'wheelchairRepair' | 'miscellaneous' | null {
     const t = normalize(text);
     if (/(hair\s*care|haircare)/.test(t)) return 'haircare';
     if (/(foot\s*care|footcare)/.test(t)) return 'footcare';
     if (/pharmacy/.test(t)) return 'pharmacy';
     if (/(cable|tv)/.test(t)) return 'cable';
+    if (/(misc|miscellaneous|other|general)/.test(t)) return 'miscellaneous';
     if (/(wheelchair\s*repair|wheelchairrepair)/.test(t)) return 'wheelchairRepair';
     return null;
   }
@@ -106,7 +107,7 @@ export function useOmIntentExecutor() {
     // All transactions in 'service type' batch (latest batch by that type)
     if (/all\s+transactions\s+in\s+.+\s+batch/.test(q) || (/transactions/.test(q) && /batch/.test(q))) {
       const st = parseServiceType(q);
-      if (!st) return 'Please specify a service type (haircare, footcare, pharmacy, cable, wheelchair repair).';
+      if (!st) return 'Please specify a service type (haircare, footcare, pharmacy, cable, miscellaneous, wheelchair repair).';
       const batches = getFacilityServiceBatches(facilityId, st);
       if (!batches || batches.length === 0) return `No ${st} batches found.`;
       const latest = batches.slice().sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())[0];

--- a/frontend/src/types/database.ts
+++ b/frontend/src/types/database.ts
@@ -155,6 +155,7 @@ export interface Database {
             pharmacy: boolean
             cable: boolean
             wheelchairRepair: boolean
+            miscellaneous: boolean
           }
           service_authorizations: {
             haircare: boolean
@@ -162,6 +163,7 @@ export interface Database {
             pharmacy: boolean
             cable: boolean
             wheelchairRepair: boolean
+            miscellaneous: boolean
           } | null
         }
         Insert: {
@@ -190,6 +192,7 @@ export interface Database {
             pharmacy: boolean
             cable: boolean
             wheelchairRepair: boolean
+            miscellaneous: boolean
           }
           service_authorizations?: {
             haircare: boolean
@@ -197,6 +200,7 @@ export interface Database {
             pharmacy: boolean
             cable: boolean
             wheelchairRepair: boolean
+            miscellaneous: boolean
           } | null
         }
         Update: {
@@ -225,6 +229,7 @@ export interface Database {
             pharmacy: boolean
             cable: boolean
             wheelchairRepair: boolean
+            miscellaneous: boolean
           }
           service_authorizations?: {
             haircare: boolean
@@ -232,6 +237,7 @@ export interface Database {
             pharmacy: boolean
             cable: boolean
             wheelchairRepair: boolean
+            miscellaneous: boolean
           } | null
         }
       }
@@ -363,7 +369,7 @@ export interface Database {
         Row: {
           id: string
           facility_id: string
-          service_type: 'haircare' | 'footcare' | 'pharmacy' | 'cable' | 'wheelchairRepair'
+          service_type: 'haircare' | 'footcare' | 'pharmacy' | 'cable' | 'wheelchairRepair' | 'miscellaneous'
           status: 'open' | 'posted'
           created_at: string
           posted_at: string | null
@@ -375,7 +381,7 @@ export interface Database {
         Insert: {
           id?: string
           facility_id: string
-          service_type: 'haircare' | 'footcare' | 'pharmacy' | 'cable' | 'wheelchairRepair'
+          service_type: 'haircare' | 'footcare' | 'pharmacy' | 'cable' | 'wheelchairRepair' | 'miscellaneous'
           status?: 'open' | 'posted'
           created_at?: string
           posted_at?: string | null
@@ -387,7 +393,7 @@ export interface Database {
         Update: {
           id?: string
           facility_id?: string
-          service_type?: 'haircare' | 'footcare' | 'pharmacy' | 'cable' | 'wheelchairRepair'
+          service_type?: 'haircare' | 'footcare' | 'pharmacy' | 'cable' | 'wheelchairRepair' | 'miscellaneous'
           status?: 'open' | 'posted'
           created_at?: string
           posted_at?: string | null
@@ -770,7 +776,7 @@ export interface Database {
       resident_status: 'active' | 'inactive'
       transaction_type: 'credit' | 'debit'
       transaction_method: 'manual' | 'cash' | 'cheque'
-      service_type: 'haircare' | 'footcare' | 'pharmacy' | 'cable' | 'wheelchairRepair'
+      service_type: 'haircare' | 'footcare' | 'pharmacy' | 'cable' | 'wheelchairRepair' | 'miscellaneous'
       batch_status: 'open' | 'posted'
       batch_item_status: 'pending' | 'processed' | 'failed'
       invitation_status: 'pending' | 'accepted' | 'expired'

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -73,6 +73,7 @@ export interface Resident {
     pharmacy: boolean;
     cable: boolean;
     wheelchairRepair: boolean;
+    miscellaneous: boolean;
   };
   serviceAuthorizations?: {
     haircare: boolean;
@@ -80,6 +81,7 @@ export interface Resident {
     pharmacy: boolean;
     cable: boolean;
     wheelchairRepair: boolean;
+    miscellaneous: boolean;
   };
 }
 
@@ -106,7 +108,7 @@ export interface AuthState {
 export interface ServiceBatch {
   id: string;
   facilityId: string;
-  serviceType: 'haircare' | 'footcare' | 'pharmacy' | 'cable' | 'wheelchairRepair';
+  serviceType: 'haircare' | 'footcare' | 'pharmacy' | 'cable' | 'wheelchairRepair' | 'miscellaneous';
   status: 'open' | 'posted';
   createdAt: string;
   postedAt?: string;

--- a/scripts/create-test-users.js
+++ b/scripts/create-test-users.js
@@ -158,7 +158,8 @@ async function createSampleResidents(facilityId, residentUsers) {
         footcare: true,
         pharmacy: true,
         cable: false,
-        wheelchairRepair: false
+        wheelchairRepair: false,
+        miscellaneous: false
       }
     },
     {
@@ -176,7 +177,8 @@ async function createSampleResidents(facilityId, residentUsers) {
         footcare: true,
         pharmacy: true,
         cable: true,
-        wheelchairRepair: true
+        wheelchairRepair: true,
+        miscellaneous: true
       }
     },
     {
@@ -194,7 +196,8 @@ async function createSampleResidents(facilityId, residentUsers) {
         footcare: true,
         pharmacy: true,
         cable: true,
-        wheelchairRepair: false
+        wheelchairRepair: false,
+        miscellaneous: true
       }
     }
   ]

--- a/scripts/create-test-users.ts
+++ b/scripts/create-test-users.ts
@@ -176,7 +176,8 @@ async function createSampleResidents(facilityId: string, residentUsers: any[]) {
         footcare: true,
         pharmacy: true,
         cable: false,
-        wheelchairRepair: false
+        wheelchairRepair: false,
+        miscellaneous: false
       }
     },
     {
@@ -194,7 +195,8 @@ async function createSampleResidents(facilityId: string, residentUsers: any[]) {
         footcare: true,
         pharmacy: true,
         cable: true,
-        wheelchairRepair: true
+        wheelchairRepair: true,
+        miscellaneous: true
       }
     },
     {
@@ -212,7 +214,8 @@ async function createSampleResidents(facilityId: string, residentUsers: any[]) {
         footcare: true,
         pharmacy: true,
         cable: true,
-        wheelchairRepair: false
+        wheelchairRepair: false,
+        miscellaneous: true
       }
     }
   ]

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -117,7 +117,7 @@ CREATE TABLE public.residents (
   created_at timestamp with time zone DEFAULT now(),
   facility_id uuid NOT NULL,
   bank_details jsonb,
-  allowed_services jsonb NOT NULL DEFAULT '{"cable": false, "footcare": false, "haircare": false, "pharmacy": false, "wheelchairRepair": false}'::jsonb,
+  allowed_services jsonb NOT NULL DEFAULT '{"cable": false, "footcare": false, "haircare": false, "pharmacy": false, "wheelchairRepair": false, "miscellaneous": false}'::jsonb,
   service_authorizations jsonb,
   CONSTRAINT residents_pkey PRIMARY KEY (id),
   CONSTRAINT residents_linked_user_id_fkey FOREIGN KEY (linked_user_id) REFERENCES public.users(id),


### PR DESCRIPTION
Add "miscellaneous" as a new service batch type across frontend, backend, and database to enable its use in OM and resident/POA dashboards.

---
<a href="https://cursor.com/background-agent?bcId=bc-396a3da8-db6f-42f7-b7f4-b7b80a9cd70c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-396a3da8-db6f-42f7-b7f4-b7b80a9cd70c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

