### PR TITLE
Fix duplicate cash receipt printing

### DIFF
--- a/frontend/src/components/CashBoxPage.tsx
+++ b/frontend/src/components/CashBoxPage.tsx
@@ -288,7 +288,6 @@ export default function CashBoxPage({ onBack }: CashBoxPageProps) {
     printWindow.document.open();
     printWindow.document.write(receiptHTML);
     printWindow.document.close();
-    printWindow.print();
   };
 
   const handleReset = async () => {


### PR DESCRIPTION
Remove duplicate print trigger for cash receipts to ensure a single print dialog.

---
<a href="https://cursor.com/background-agent?bcId=bc-8b84088b-3dbc-45e7-95d9-bb621747b399"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8b84088b-3dbc-45e7-95d9-bb621747b399"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

