### PR TITLE
Fix resident password reset link

### DIFF
--- a/backend/services/app/database.ts
+++ b/backend/services/app/database.ts
@@ -699,7 +699,8 @@ export async function createResidentWithLinkedUser(params: {
       throw linkError;
     }
 
-    const baseUrl = typeof window !== 'undefined' ? window.location.origin : '';
+    const siteUrlEnv = process.env.PUBLIC_SITE_URL || process.env.VITE_PUBLIC_SITE_URL || '';
+    const baseUrl = siteUrlEnv.replace(/\/$/, '') || (typeof window !== 'undefined' ? window.location.origin : '');
     const redirectTo = `${baseUrl}/reset-password/resident`;
     const { error: resetError } = await supabaseAdmin.auth.resetPasswordForEmail(email, { redirectTo });
     if (resetError) {
@@ -761,7 +762,8 @@ export async function createResidentWithLinkedUser(params: {
       throw linkError;
     }
 
-    const baseUrl = typeof window !== 'undefined' ? window.location.origin : '';
+    const siteUrlEnv = process.env.PUBLIC_SITE_URL || process.env.VITE_PUBLIC_SITE_URL || '';
+    const baseUrl = siteUrlEnv.replace(/\/$/, '') || (typeof window !== 'undefined' ? window.location.origin : '');
     const redirectTo = `${baseUrl}/reset-password/resident`;
     const { error: resetError } = await supabaseAdmin.auth.resetPasswordForEmail(email, { redirectTo });
     if (resetError) {
@@ -865,7 +867,8 @@ export async function clearFacilityForUser(userId: string): Promise<void> {
 export async function sendRoleBasedResetPasswordEmail(params: { email: string; role: 'OM' | 'POA' | 'Resident' | 'Vendor'; siteUrl?: string }) {
   const email = params.email.trim().toLowerCase();
   const roleNorm = params.role;
-  const baseUrl = params.siteUrl || (typeof window !== 'undefined' ? window.location.origin : '');
+  const envSite = process.env.PUBLIC_SITE_URL || process.env.VITE_PUBLIC_SITE_URL || '';
+  const baseUrl = (params.siteUrl || envSite).replace(/\/$/, '') || (typeof window !== 'undefined' ? window.location.origin : '');
   const redirectPath = roleNorm === 'OM'
     ? '/reset-password/om'
     : roleNorm === 'Vendor'

--- a/server/index.ts
+++ b/server/index.ts
@@ -38,7 +38,7 @@ if (!serviceRoleKey) {
 const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey);
 const supabaseAnon = anonKey ? createClient(supabaseUrl, anonKey) : null as any;
 
-const siteUrl = process.env.PUBLIC_SITE_URL || process.env.VITE_PUBLIC_SITE_URL || 'http://localhost:5173';
+const siteUrl = (process.env.PUBLIC_SITE_URL || process.env.VITE_PUBLIC_SITE_URL || 'http://localhost:5173').replace(/\/$/, '');
 
 // Helper to build a PayPal client per facility
 function createPayPalClient(config: { clientId: string; clientSecret: string; environment?: 'sandbox' | 'live' }) {
@@ -121,7 +121,9 @@ app.post('/api/auth/invite', async (req, res) => {
       return res.status(400).json({ error: 'Missing email' });
     }
 
-    const finalRedirect = (typeof redirectTo === 'string' && redirectTo) ? redirectTo : 'https://vaultiq.ca';
+    const finalRedirect = (typeof redirectTo === 'string' && redirectTo)
+      ? redirectTo
+      : `${siteUrl}/reset-password/resident`;
 
     const { data, error } = await supabaseAdmin.auth.admin.inviteUserByEmail(email, {
       redirectTo: finalRedirect,
@@ -323,7 +325,7 @@ app.post('/api/users/provision', async (req, res) => {
     // Step 4: Send email for POA/Resident only
     if (role === 'POA' || role === 'Resident') {
       const { error: inviteErr } = await supabaseAdmin.auth.admin.inviteUserByEmail(email, {
-        redirectTo: 'https://vaultiq.ca',
+        redirectTo: `${siteUrl}/reset-password/resident`,
         data: userMetadata,
       });
       if (inviteErr) {


### PR DESCRIPTION
Fix password reset and invite email redirects to use absolute URLs from environment variables, ensuring POA/Resident links go to `/reset-password/resident`.

---
<a href="https://cursor.com/background-agent?bcId=bc-9f47b0dd-230d-4287-bcba-dd6f8c435ce0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9f47b0dd-230d-4287-bcba-dd6f8c435ce0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

