### PR TITLE
Fix password reset redirection to trust1.netlify.app

### DIFF
--- a/backend/services/app/database.ts
+++ b/backend/services/app/database.ts
@@ -697,7 +697,7 @@ export async function createResidentWithLinkedUser(params: {
 
     const siteUrlEnv = process.env.PUBLIC_SITE_URL || process.env.VITE_PUBLIC_SITE_URL || '';
     const baseUrl = siteUrlEnv.replace(/\/$/, '') || (typeof window !== 'undefined' ? window.location.origin : '');
-    const redirectTo = `${baseUrl}/reset-password/resident`;
+    const redirectTo = `${baseUrl}/reset-password/resident/`;
     const { error: resetError } = await supabaseAdmin.auth.resetPasswordForEmail(email, { redirectTo });
     if (resetError) {
       throw resetError;
@@ -760,7 +760,7 @@ export async function createResidentWithLinkedUser(params: {
 
     const siteUrlEnv = process.env.PUBLIC_SITE_URL || process.env.VITE_PUBLIC_SITE_URL || '';
     const baseUrl = siteUrlEnv.replace(/\/$/, '') || (typeof window !== 'undefined' ? window.location.origin : '');
-    const redirectTo = `${baseUrl}/reset-password/resident`;
+    const redirectTo = `${baseUrl}/reset-password/resident/`;
     const { error: resetError } = await supabaseAdmin.auth.resetPasswordForEmail(email, { redirectTo });
     if (resetError) {
       throw resetError;
@@ -863,7 +863,7 @@ export async function clearFacilityForUser(userId: string): Promise<void> {
 export async function sendRoleBasedResetPasswordEmail(params: { email: string; role: 'OM' | 'POA' | 'Resident' | 'Vendor'; siteUrl?: string }) {
   const email = params.email.trim().toLowerCase();
   const roleNorm = params.role;
-  const envSite = process.env.PUBLIC_SITE_URL || process.env.VITE_PUBLIC_SITE_URL || '';
+  const envSite = process.env.PUBLIC_SITE_URL || process.env.VITE_PUBLIC_SITE_URL || 'https://trust1.netlify.app';
   const baseUrl = (params.siteUrl || envSite).replace(/\/$/, '') || (typeof window !== 'undefined' ? window.location.origin : '');
   const redirectPath = roleNorm === 'OM'
     ? '/reset-password/om'
@@ -2147,7 +2147,7 @@ export async function sendInvitationEmail(invitation: SignupInvitation, facility
         facilityId: invitation.facilityId,
         residentId: invitation.residentId,
         name: undefined,
-        redirectTo: `https://vaultiq.ca`
+        redirectTo: `https://trust1.netlify.app/reset-password/resident/`
       }),
     });
 
@@ -2796,7 +2796,7 @@ export async function provisionUser(params: { email: string; name?: string; role
 
   if (role === 'POA' || role === 'Resident') {
     const { error: inviteErr } = await (getSupabaseAdmin() as any).auth.admin.inviteUserByEmail(email, {
-      redirectTo: 'https://vaultiq.ca',
+      redirectTo: 'https://trust1.netlify.app/reset-password/resident/',
       data: userMetadata,
     });
     if (inviteErr) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -124,6 +124,7 @@ function AppContent() {
       <Route path="/login" element={isAuthenticated ? <Navigate to="/" replace /> : <AuthPage />} />
       <Route path="/reset-password/om" element={<ResetPasswordOM />} />
       <Route path="/reset-password/resident" element={<ResetPasswordResident />} />
+      <Route path="/reset-password/resident/" element={<ResetPasswordResident />} />
       <Route path="/reset-password/vendor" element={<ResetPasswordVendor />} />
 
       <Route

--- a/server/index.ts
+++ b/server/index.ts
@@ -38,7 +38,7 @@ if (!serviceRoleKey) {
 const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey);
 const supabaseAnon = anonKey ? createClient(supabaseUrl, anonKey) : null as any;
 
-const siteUrl = (process.env.PUBLIC_SITE_URL || process.env.VITE_PUBLIC_SITE_URL || 'http://localhost:5173').replace(/\/$/, '');
+const siteUrl = (process.env.PUBLIC_SITE_URL || process.env.VITE_PUBLIC_SITE_URL || 'https://trust1.netlify.app').replace(/\/$/, '');
 
 // Helper to build a PayPal client per facility
 function createPayPalClient(config: { clientId: string; clientSecret: string; environment?: 'sandbox' | 'live' }) {
@@ -123,7 +123,7 @@ app.post('/api/auth/invite', async (req, res) => {
 
     const finalRedirect = (typeof redirectTo === 'string' && redirectTo)
       ? redirectTo
-      : `${siteUrl}/reset-password/resident`;
+      : `${siteUrl}/reset-password/resident/`;
 
     const { data, error } = await supabaseAdmin.auth.admin.inviteUserByEmail(email, {
       redirectTo: finalRedirect,
@@ -325,7 +325,7 @@ app.post('/api/users/provision', async (req, res) => {
     // Step 4: Send email for POA/Resident only
     if (role === 'POA' || role === 'Resident') {
       const { error: inviteErr } = await supabaseAdmin.auth.admin.inviteUserByEmail(email, {
-        redirectTo: `${siteUrl}/reset-password/resident`,
+        redirectTo: `${siteUrl}/reset-password/resident/`,
         data: userMetadata,
       });
       if (inviteErr) {


### PR DESCRIPTION
Standardize password reset redirects to `https://trust1.netlify.app/reset-password/resident/` and update frontend routing to handle the trailing slash.

Password reset flows were failing or redirecting incorrectly due to inconsistent URLs (some missing trailing slashes, some using an old domain `vaultiq.ca`). This PR ensures all backend redirects point to the correct Netlify URL with a trailing slash and adds a corresponding frontend route to handle it.

---
<a href="https://cursor.com/background-agent?bcId=bc-30c72591-9df2-4c37-92b3-e022ed261fc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-30c72591-9df2-4c37-92b3-e022ed261fc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

