### PR TITLE
Fix broken signup confirmation redirect

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -184,7 +184,7 @@ app.post('/api/auth/invite', async (req, res) => {
 
     const finalRedirect = (typeof redirectTo === 'string' && redirectTo)
       ? redirectTo
-      : `${siteUrl}/reset-password/resident/`;
+      : `${siteUrl}/confirm-signup/resident/`;
 
     const { data, error } = await supabaseAdmin.auth.admin.inviteUserByEmail(email, {
       redirectTo: finalRedirect,


### PR DESCRIPTION
Implement session-to-cookie exchange for `ConfirmSignupResident` and align the default server invite redirect path.

The `ConfirmSignupResident` component now explicitly exchanges the Supabase access token for server cookies, ensuring subsequent API calls requiring authentication succeed. Additionally, the server's default invite `redirectTo` path has been updated to consistently point to `/confirm-signup/resident/` when no specific redirect is provided. These changes ensure the `confirm-signup` flow is as robust and consistent as the `reset-password` flow.

---
<a href="https://cursor.com/background-agent?bcId=bc-fbcfdada-5ab5-461c-a1e2-f4f5fbc8d331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fbcfdada-5ab5-461c-a1e2-f4f5fbc8d331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

