### PR TITLE
Fix cash box balance reset bug

### DIFF
--- a/frontend/src/components/CashBoxPage.tsx
+++ b/frontend/src/components/CashBoxPage.tsx
@@ -289,11 +289,12 @@ Are you sure you want to continue?`;
         // Generate report
         await generateMonthlyReport();
         
-        // Update balance
-        setBalance(2500.00);
+        // Reload balance from DB to reflect true post-reset balance
+        const reloaded = await getCashBoxBalance(currentFacility.id);
+        setBalance(reloaded);
         
-        // Clear current month transactions
-        alert('Cash box has been reset to $2500.00. Monthly report has been generated.');
+        // Notify
+        alert('Cash box has been reset. Monthly report has been generated.');
       } else {
         alert(result.error || 'Failed to reset cash box');
       }

--- a/frontend/src/contexts/DataContextSupabase.tsx
+++ b/frontend/src/contexts/DataContextSupabase.tsx
@@ -1436,10 +1436,11 @@ export function DataProvider({ children }: { children: ReactNode }) {
     resetCashBoxToMonthlyAmount: async (facilityId: string, userId: string) => {
       const result = await resetCashBoxMonthlyDb(facilityId, userId);
       if (result.success) {
-        // Update local state to default balance
+        // Reload from DB to avoid hard-coded values
+        const balance = await getCashBoxBalanceDb(facilityId);
         setCashBoxBalances(prev => ({
           ...prev,
-          [facilityId]: 2500.00
+          [facilityId]: balance
         }));
       } else {
         throw new Error(result.error || 'Failed to reset cash box');

--- a/frontend/src/services/cashbox-database.ts
+++ b/frontend/src/services/cashbox-database.ts
@@ -32,8 +32,16 @@ export async function initializeCashBoxBalance(
   facilityId: string,
   userId: string
 ): Promise<{ success: boolean; balance?: number; initialized?: boolean; error?: string }> {
-  // For now call resetCashBoxToMonthly which initializes if missing
-  return rpcCall('resetCashBoxToMonthly', [facilityId, userId])
+  try {
+    const { data, error } = await supabase.rpc('initialize_cash_box_balance', {
+      p_facility_id: facilityId,
+      p_user_id: userId
+    });
+    if (error) throw error;
+    return data as any;
+  } catch (e: any) {
+    return { success: false, error: e?.message || 'Unknown error' };
+  }
 }
 
 // Get current cash box balance for a facility

--- a/frontend/src/services/cashbox-database.ts
+++ b/frontend/src/services/cashbox-database.ts
@@ -55,10 +55,8 @@ export async function getCashBoxBalance(facilityId: string): Promise<number> {
     if (error) {
       return 0;
     }
-    if (!data) {
-      // If no row exists yet, default to starting monthly amount
-      return 2500.0;
-    }
+    // If no row exists yet, return 0; initialization happens on community create or explicit reset
+    if (!data) return 0;
     return Number((data as any).balance || 0);
   } catch (e) {
     return 0;


### PR DESCRIPTION
Prevent cash box balance from resetting to 2500 on every load by ensuring it only updates on new community creation or explicit user reset.

---
<a href="https://cursor.com/background-agent?bcId=bc-55002d65-a96d-434e-a959-e6cef7cec778"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-55002d65-a96d-434e-a959-e6cef7cec778"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

