### PR TITLE
Refactor getCashBoxBalance to backend only

### DIFF
--- a/backend/server/index.ts
+++ b/backend/server/index.ts
@@ -4,6 +4,7 @@ import { FRONTEND_URL, PORT } from '../config/env.js';
 import { createOrder, captureOrder } from '../services/payments.js';
 import { getItems } from '../services/db.js';
 import * as appDb from '../services/app/database.js';
+import * as appCashbox from '../services/app/cashbox-database.js';
 import * as appPaypal from '../services/app/paypal.js';
 
 const app = express();
@@ -124,7 +125,7 @@ const rpcAllowlist: Record<string, any> = {
   resetCashBoxToMonthly: appDb.resetCashBoxToMonthly,
   getMonthlyCashBoxHistory: appDb.getMonthlyCashBoxHistory,
   getCashBoxTransactionsByMonthYear: appDb.getCashBoxTransactionsByMonthYear,
-  getCashBoxBalanceServer: appDb.getCashBoxBalance,
+  getCashBoxBalanceServer: appCashbox.getCashBoxBalance,
   // paypal config
   fetchPayPalConfig: appPaypal.fetchPayPalConfig,
 };

--- a/backend/services/app/database.ts
+++ b/backend/services/app/database.ts
@@ -2567,24 +2567,6 @@ export async function closeMonthlyPreAuthList(listId: string, closedBy: string):
   }
 }
 
-// Cash Box Functions
-export async function getCashBoxBalance(facilityId: string): Promise<number> {
-  try {
-    const { data, error } = await supabase
-      .from('cash_box_balances')
-      .select('balance')
-      .eq('facility_id', facilityId)
-      .maybeSingle();
-    if (error) {
-      return 0;
-    }
-    const bal = (data as any)?.balance;
-    return typeof bal === 'number' ? bal : Number(bal ?? 0);
-  } catch (_) {
-    return 0;
-  }
-}
-
 
 export async function updateCashBoxBalanceWithTransaction(
   facilityId: string,


### PR DESCRIPTION
Unify `getCashBoxBalance` in `cashbox-database.ts` and refactor frontend to use the server RPC for consistent database fetching.

---
<a href="https://cursor.com/background-agent?bcId=bc-3f33b69a-20b5-4b1d-ba1c-4d07e9011f1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3f33b69a-20b5-4b1d-ba1c-4d07e9011f1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

