### PR TITLE
Fix signup link permissions and format

### DIFF
--- a/backend/services/app/database.ts
+++ b/backend/services/app/database.ts
@@ -2147,7 +2147,7 @@ export async function sendInvitationEmail(invitation: SignupInvitation, facility
         facilityId: invitation.facilityId,
         residentId: invitation.residentId,
         name: undefined,
-        redirectTo: `https://trust1.netlify.app/confirm-signup/resident/`
+        redirectTo: `${(process.env.PUBLIC_SITE_URL || process.env.VITE_PUBLIC_SITE_URL || 'https://trust1.netlify.app').replace(/\/$/, '')}/confirm-signup/resident/`
       }),
     });
 
@@ -2828,8 +2828,9 @@ export async function provisionUser(params: { email: string; name?: string; role
   }
 
   if (role === 'POA' || role === 'Resident') {
+    const siteBase = (process.env.PUBLIC_SITE_URL || process.env.VITE_PUBLIC_SITE_URL || 'https://trust1.netlify.app').replace(/\/$/, '');
     const { error: inviteErr } = await (getSupabaseAdmin() as any).auth.admin.inviteUserByEmail(email, {
-      redirectTo: 'https://trust1.netlify.app/confirm-signup/resident/',
+      redirectTo: `${siteBase}/confirm-signup/resident/`,
       data: userMetadata,
     });
     if (inviteErr) {

--- a/server/index.ts
+++ b/server/index.ts
@@ -183,7 +183,7 @@ app.post('/api/auth/invite', async (req, res) => {
     }
 
     const finalRedirect = (typeof redirectTo === 'string' && redirectTo)
-      ? redirectTo
+      ? String(redirectTo).replace(/#$/, '')
       : `${siteUrl}/confirm-signup/resident/`;
 
     const { data, error } = await supabaseAdmin.auth.admin.inviteUserByEmail(email, {


### PR DESCRIPTION
Fix signup confirmation links to prevent trailing '#' and use environment-based URLs for proper routing.

Previously, confirmation links could end with a '#' character, interfering with frontend routing and Supabase's hash-based token parsing. This PR ensures the URL is clean and correctly processed by the `ConfirmSignupResident` component.

---
<a href="https://cursor.com/background-agent?bcId=bc-35870bd9-ef27-4ccf-8245-1b932e86b29d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-35870bd9-ef27-4ccf-8245-1b932e86b29d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

