### PR TITLE
Fix resident password reset redirect link

### DIFF
--- a/backend/services/app/database.ts
+++ b/backend/services/app/database.ts
@@ -695,9 +695,9 @@ export async function createResidentWithLinkedUser(params: {
       throw linkError;
     }
 
-    const siteUrlEnv = process.env.PUBLIC_SITE_URL || process.env.VITE_PUBLIC_SITE_URL || '';
+    const siteUrlEnv = process.env.PUBLIC_SITE_URL || process.env.VITE_PUBLIC_SITE_URL || 'https://trust1.netlify.app';
     const baseUrl = siteUrlEnv.replace(/\/$/, '') || (typeof window !== 'undefined' ? window.location.origin : '');
-    const redirectTo = `${baseUrl}/confirm-signup/resident/`;
+    const redirectTo = `${baseUrl}/reset-password/resident/`;
     const { error: resetError } = await supabaseAdmin.auth.resetPasswordForEmail(email, { redirectTo });
     if (resetError) {
       throw resetError;
@@ -758,9 +758,9 @@ export async function createResidentWithLinkedUser(params: {
       throw linkError;
     }
 
-    const siteUrlEnv = process.env.PUBLIC_SITE_URL || process.env.VITE_PUBLIC_SITE_URL || '';
+    const siteUrlEnv = process.env.PUBLIC_SITE_URL || process.env.VITE_PUBLIC_SITE_URL || 'https://trust1.netlify.app';
     const baseUrl = siteUrlEnv.replace(/\/$/, '') || (typeof window !== 'undefined' ? window.location.origin : '');
-    const redirectTo = `${baseUrl}/confirm-signup/resident/`;
+    const redirectTo = `${baseUrl}/reset-password/resident/`;
     const { error: resetError } = await supabaseAdmin.auth.resetPasswordForEmail(email, { redirectTo });
     if (resetError) {
       throw resetError;
@@ -869,7 +869,7 @@ export async function sendRoleBasedResetPasswordEmail(params: { email: string; r
     ? '/reset-password/om'
     : roleNorm === 'Vendor'
       ? '/reset-password/vendor'
-      : '/confirm-signup/resident';
+      : '/reset-password/resident/';
   const redirectTo = `${baseUrl}${redirectPath}`;
 
   // Prefer admin client if available in this module; fallback to public supabase


### PR DESCRIPTION
Correct password reset email redirect URLs for residents/POAs to `/reset-password/resident/` and set a default site URL fallback.

---
<a href="https://cursor.com/background-agent?bcId=bc-90719ea3-df62-4545-8a01-698806c08260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-90719ea3-df62-4545-8a01-698806c08260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

