### PR TITLE
Fix email link authentication after adding users

### DIFF
--- a/frontend/src/components/ResetPasswordResident.tsx
+++ b/frontend/src/components/ResetPasswordResident.tsx
@@ -19,32 +19,24 @@ export default function ResetPasswordResident() {
     let isMounted = true;
     const processAuthFromUrl = async () => {
       try {
-        const hash = typeof window !== 'undefined' ? window.location.hash : '';
-        if (hash === '#') {
-          if (typeof window !== 'undefined') {
-            window.history.replaceState({}, '', window.location.pathname + window.location.search);
-          }
+        if (typeof window === 'undefined') return;
+        const { hash, search, pathname } = window.location;
+        const hashParams = hash && hash !== '#' ? new URLSearchParams(hash.substring(1)) : new URLSearchParams();
+        const queryParams = search ? new URLSearchParams(search) : new URLSearchParams();
+        const accessToken = hashParams.get('access_token') || queryParams.get('access_token');
+        const refreshToken = hashParams.get('refresh_token') || queryParams.get('refresh_token');
+        const code = hashParams.get('code') || queryParams.get('code');
+
+        if (accessToken && refreshToken) {
+          await supabase.auth.setSession({ access_token: accessToken, refresh_token: refreshToken });
+          window.history.replaceState({}, '', pathname);
           return;
         }
-        if (hash && hash.length > 1) {
-          const params = new URLSearchParams(hash.substring(1));
-          const accessToken = params.get('access_token');
-          const refreshToken = params.get('refresh_token');
-          const code = params.get('code');
-
-          if (accessToken && refreshToken) {
-            await supabase.auth.setSession({ access_token: accessToken, refresh_token: refreshToken });
-            if (typeof window !== 'undefined') {
-              window.history.replaceState({}, '', window.location.pathname + window.location.search);
-            }
-          } else if (code) {
-            try {
-              await supabase.auth.exchangeCodeForSession(code);
-            } catch (_) {}
-            if (typeof window !== 'undefined') {
-              window.history.replaceState({}, '', window.location.pathname + window.location.search);
-            }
-          }
+        if (code) {
+          try {
+            await supabase.auth.exchangeCodeForSession(code);
+          } catch (_) {}
+          window.history.replaceState({}, '', pathname);
         }
       } catch (_) {}
     };


### PR DESCRIPTION
Enable parsing of Supabase auth tokens from both URL hash and query string to fix 'Not authenticated' errors for resident email links.

Previously, the application only checked the URL hash for Supabase authentication parameters (e.g., `access_token`, `refresh_token`, `code`). However, Supabase can also provide these parameters in the URL query string. This led to a 'Not authenticated' error when users clicked email invitation or reset links that used query string parameters, as the tokens were not being correctly processed to establish a session.

---
<a href="https://cursor.com/background-agent?bcId=bc-b2c02535-ca9b-43ef-8704-23d141b785a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b2c02535-ca9b-43ef-8704-23d141b785a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

