### PR TITLE
Save and record resident service acceptance

### DIFF
--- a/frontend/src/components/ConfirmSignupResident.tsx
+++ b/frontend/src/components/ConfirmSignupResident.tsx
@@ -202,10 +202,9 @@ export default function ConfirmSignupResident() {
     setUpdating(true);
     setError('');
     try {
-      const token = (await supabase.auth.getSession()).data.session?.access_token || null;
       const resp = await fetch(`${String(API_BASE).replace(/\/+$/, '')}/api/residents/services`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...(token ? { Authorization: `Bearer ${token}` } : {}) },
+        headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
         body: JSON.stringify({ allowedServices: selectedServices })
       });
@@ -239,10 +238,9 @@ export default function ConfirmSignupResident() {
     }
     setSubmitting(true);
     try {
-      const token = (await supabase.auth.getSession()).data.session?.access_token || null;
       const resp = await fetch(`${String(API_BASE).replace(/\/+$/, '')}/api/auth/update-password`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...(token ? { Authorization: `Bearer ${token}` } : {}) },
+        headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
         body: JSON.stringify({ password })
       });

--- a/server/index.ts
+++ b/server/index.ts
@@ -646,9 +646,13 @@ app.post('/api/residents/services', async (req, res) => {
       .maybeSingle();
     if (rErr || !residentRow) return res.status(404).json({ error: rErr?.message || 'Resident not found' });
 
+    // Record both allowed services and acceptance snapshot in service_authorizations
     const { error: upErr } = await supabaseAdmin
       .from('residents')
-      .update({ allowed_services: allowedServices })
+      .update({
+        allowed_services: allowedServices,
+        service_authorizations: allowedServices
+      })
       .eq('id', (residentRow as any).id);
     if (upErr) return res.status(400).json({ error: upErr.message });
     return res.json({ success: true });


### PR DESCRIPTION
Streamline confirm signup flow by removing redundant Supabase session fetches, explicitly recording service acceptance, and enabling password setting.

---
<a href="https://cursor.com/background-agent?bcId=bc-b4afc4ad-b6e8-4f8f-b78e-9a2b055aa763"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b4afc4ad-b6e8-4f8f-b78e-9a2b055aa763"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

