### PR TITLE
Enable all services by default for new residents

### DIFF
--- a/frontend/src/components/ResidentForm.tsx
+++ b/frontend/src/components/ResidentForm.tsx
@@ -32,7 +32,7 @@ export default function ResidentForm({ onClose }: ResidentFormProps) {
       pharmacy: true,
       cable: true,
       wheelchairRepair: true,
-      miscellaneous: false
+      miscellaneous: true
     }
   });
 const [formError, setFormError] = useState<string | null>(null);


### PR DESCRIPTION
Set `miscellaneous` service to be allowed by default when adding a resident to ensure all services are pre-selected.

---
<a href="https://cursor.com/background-agent?bcId=bc-55759d9c-e365-48a2-8806-a491c11f3034"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-55759d9c-e365-48a2-8806-a491c11f3034"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

