### PR TITLE
Update password in confirm signup

### DIFF
--- a/frontend/src/components/ConfirmSignupResident.tsx
+++ b/frontend/src/components/ConfirmSignupResident.tsx
@@ -250,9 +250,14 @@ export default function ConfirmSignupResident() {
     }
     setSubmitting(true);
     try {
+      const { data } = await supabase.auth.getSession();
+      const accessToken = data.session?.access_token || null;
       const resp = await fetch(`${String(API_BASE).replace(/\/+$/, '')}/api/auth/update-password`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+        },
         credentials: 'include',
         body: JSON.stringify({ password })
       });


### PR DESCRIPTION
Add bearer token to `update-password` API call in confirm signup to ensure backend authentication.

---
<a href="https://cursor.com/background-agent?bcId=bc-40ce2156-4ebb-4f8a-ba9b-4d2cf869a80d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-40ce2156-4ebb-4f8a-ba9b-4d2cf869a80d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

