### PR TITLE
Update confirm-signup password logic

### DIFF
--- a/frontend/src/components/ConfirmSignupResident.tsx
+++ b/frontend/src/components/ConfirmSignupResident.tsx
@@ -250,16 +250,8 @@ export default function ConfirmSignupResident() {
     }
     setSubmitting(true);
     try {
-      const resp = await fetch(`${String(API_BASE).replace(/\/+$/, '')}/api/auth/update-password`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ password })
-      });
-      if (!resp.ok) {
-        const body = await resp.json().catch(() => ({}));
-        throw new Error(body?.error || 'Failed to update password');
-      }
+      const { error } = await supabase.auth.updateUser({ password });
+      if (error) throw error;
       setMessage('Setup complete. You can now sign in.');
     } catch (e: any) {
       setError(e?.message || 'Failed to update password');


### PR DESCRIPTION
Update `ConfirmSignupResident` to use `supabase.auth.updateUser` for password updates, mirroring the `reset-password` flow.

---
<a href="https://cursor.com/background-agent?bcId=bc-25e06fb6-072f-4074-92be-253c434693af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-25e06fb6-072f-4074-92be-253c434693af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

