### PR TITLE
Manage resident mail delivery preferences and reporting

### DIFF
--- a/backend/server/index.ts
+++ b/backend/server/index.ts
@@ -154,6 +154,9 @@ const rpcAllowlist: Record<string, any> = {
   createVendorUserAndLink: appDb.createVendorUserAndLink,
   unlinkVendorFromFacility: appDb.unlinkVendorFromFacility,
   linkVendorToFacility: appDb.linkVendorToFacility,
+  // mail delivery preferences
+  updateResidentMailPreference: appDb.updateResidentMailPreference,
+  listResidentMailPreferencesByFacility: appDb.listResidentMailPreferencesByFacility,
   createSignupInvitation: appDb.createSignupInvitation,
   createSignupInvitationForResident: appDb.createSignupInvitationForResident,
   sendInvitationEmail: appDb.sendInvitationEmail,

--- a/backend/types/models.ts
+++ b/backend/types/models.ts
@@ -36,6 +36,8 @@ export interface Resident {
   bankDetails?: any;
   allowedServices: any;
   serviceAuthorizations?: any;
+  mailDeliveryPreference?: 'resident_room' | 'reception' | 'other';
+  mailDeliveryNote?: string;
 }
 
 export interface Transaction {

--- a/frontend/src/components/OMDashboard.tsx
+++ b/frontend/src/components/OMDashboard.tsx
@@ -1077,6 +1077,68 @@ export default function OMDashboard() {
               </div>
             </div>
 
+            {/* Residents Mail Preferences Overview */}
+            <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+              <div className="mb-4 flex items-center justify-between">
+                <div>
+                  <h3 className="text-md font-semibold text-gray-900">Resident Mail Delivery Preferences</h3>
+                  <p className="text-gray-500 text-sm">Quick view of each resident's preference for facility mail delivery</p>
+                </div>
+                <button
+                  onClick={() => {
+                    // Export CSV
+                    const rows = [['Resident', 'Preference', 'Note']].concat(
+                      facilityResidents.map(r => [
+                        r.name,
+                        r.mailDeliveryPreference || 'resident_room',
+                        r.mailDeliveryNote || ''
+                      ])
+                    );
+                    const csv = rows.map(cols => cols.map(c => '"' + String(c).replaceAll('"', '""') + '"').join(',')).join('\n');
+                    const blob = new Blob([csv], { type: 'text/csv' });
+                    const url = window.URL.createObjectURL(blob);
+                    const a = document.createElement('a');
+                    a.href = url;
+                    a.download = `resident_mail_preferences_${new Date().toISOString().split('T')[0]}.csv`;
+                    a.click();
+                    window.URL.revokeObjectURL(url);
+                  }}
+                  className="bg-blue-600 text-white px-3 py-2 rounded-lg hover:bg-blue-700 transition-colors inline-flex items-center space-x-2"
+                >
+                  <Download className="w-4 h-4" />
+                  <span>Export CSV</span>
+                </button>
+              </div>
+              <div className="overflow-x-auto border rounded-lg">
+                <table className="w-full table-auto text-sm">
+                  <thead className="bg-gray-50">
+                    <tr>
+                      <th className="px-3 py-2 text-left text-gray-600">Resident</th>
+                      <th className="px-3 py-2 text-left text-gray-600">Preference</th>
+                      <th className="px-3 py-2 text-left text-gray-600">Note</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y">
+                    {facilityResidents.length === 0 ? (
+                      <tr>
+                        <td className="px-3 py-3 text-gray-500" colSpan={3}>No residents</td>
+                      </tr>
+                    ) : (
+                      facilityResidents.map(r => (
+                        <tr key={r.id} className="hover:bg-gray-50">
+                          <td className="px-3 py-2 text-gray-900">{r.name}</td>
+                          <td className="px-3 py-2 text-gray-900">
+                            {r.mailDeliveryPreference === 'reception' ? 'Hold at Reception' : r.mailDeliveryPreference === 'other' ? 'Other' : 'Deliver to Resident Room'}
+                          </td>
+                          <td className="px-3 py-2 text-gray-900">{r.mailDeliveryNote || '-'}</td>
+                        </tr>
+                      ))
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+
             {/* Recent Activity */}
           
           </div>

--- a/frontend/src/components/POADashboard.tsx
+++ b/frontend/src/components/POADashboard.tsx
@@ -14,7 +14,7 @@ export default function POADashboard() {
   const [showMonthlyReport, setShowMonthlyReport] = useState(false);
   const [showPreAuthForm, setShowPreAuthForm] = useState(false);
   const [showOnlinePayment, setShowOnlinePayment] = useState(false);
-  const { residents, transactions, getResidentTransactions, updateResident, facilities, getResidentPreAuthDebits, isLoading } = useData();
+  const { residents, transactions, getResidentTransactions, updateResident, facilities, getResidentPreAuthDebits, isLoading, updateResidentMailPreference } = useData();
   const { user, logout } = useAuth();
 
   
@@ -222,6 +222,72 @@ export default function POADashboard() {
                   Add Funds Online
                 </button>
               </div>
+            </div>
+          </div>
+
+          {/* Mail Delivery Preference */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-lg font-semibold text-gray-900">Mail Delivery Preference</h2>
+            </div>
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm text-gray-600 mb-1">How should the facility deliver your mail?</label>
+                <select
+                  value={linkedResident.mailDeliveryPreference || 'resident_room'}
+                  onChange={async (e) => {
+                    const pref = e.target.value as 'resident_room' | 'reception' | 'other';
+                    try {
+                      if (updateResidentMailPreference) {
+                        await updateResidentMailPreference(linkedResident.id, pref, pref === 'other' ? (linkedResident.mailDeliveryNote || '') : undefined);
+                      } else {
+                        await updateResident(linkedResident.id, { mailDeliveryPreference: pref } as any);
+                      }
+                    } catch {}
+                  }}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                >
+                  <option value="resident_room">Deliver to Resident Room</option>
+                  <option value="reception">Hold at Reception</option>
+                  <option value="other">Other (specify below)</option>
+                </select>
+              </div>
+
+              {(linkedResident.mailDeliveryPreference === 'other') && (
+                <div>
+                  <label className="block text-sm text-gray-600 mb-1">Note (if Other)</label>
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="text"
+                      defaultValue={linkedResident.mailDeliveryNote || ''}
+                      placeholder="e.g., Deliver to nurse station, specific instructions"
+                      onBlur={async (e) => {
+                        try {
+                          if (updateResidentMailPreference) {
+                            await updateResidentMailPreference(linkedResident.id, 'other', e.target.value);
+                          } else {
+                            await updateResident(linkedResident.id, { mailDeliveryPreference: 'other', mailDeliveryNote: e.target.value } as any);
+                          }
+                        } catch {}
+                      }}
+                      className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    />
+                    <button
+                      onClick={async () => {
+                        try {
+                          if (updateResidentMailPreference) {
+                            await updateResidentMailPreference(linkedResident.id, 'other', linkedResident.mailDeliveryNote || '');
+                          }
+                        } catch {}
+                      }}
+                      className="px-3 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50"
+                    >
+                      Save
+                    </button>
+                  </div>
+                  <p className="text-xs text-gray-500 mt-1">This note is visible to the office manager.</p>
+                </div>
+              )}
             </div>
           </div>
 

--- a/frontend/src/contexts/DataContextSupabase.tsx
+++ b/frontend/src/contexts/DataContextSupabase.tsx
@@ -60,7 +60,8 @@ import {
   createOfficeManagerUser,
   getOmUsers,
   clearFacilityForUser
- } from '../services/database';
+} from '../services/database';
+import { updateResidentMailPreference as updateResidentMailPreferenceDb } from '../services/database';
 // Removed legacy emailService; using server-backed Supabase invites instead
 // Import cash box functions from new service
 import {
@@ -197,6 +198,7 @@ interface DataContextType {
   // Office Manager admin helpers
   listOfficeManagers: () => Promise<User[]>;
   clearOfficeManagerFacility: (userId: string) => Promise<void>;
+  updateResidentMailPreference: (residentId: string, preference: 'resident_room' | 'reception' | 'other', note?: string) => Promise<void>;
 }
 
 const DataContext = createContext<DataContextType | undefined>(undefined);
@@ -530,6 +532,15 @@ export function DataProvider({ children }: { children: ReactNode }) {
       );
     } catch (err) {
       throw err;
+    }
+  };
+
+  const updateResidentMailPreference = async (residentId: string, preference: 'resident_room' | 'reception' | 'other', note?: string) => {
+    try {
+      const updated = await updateResidentMailPreferenceDb(residentId, preference, note);
+      setResidents(prev => prev.map(r => r.id === residentId ? { ...r, mailDeliveryPreference: updated.mailDeliveryPreference, mailDeliveryNote: updated.mailDeliveryNote } : r));
+    } catch (e) {
+      throw e;
     }
   };
 
@@ -1506,7 +1517,8 @@ export function DataProvider({ children }: { children: ReactNode }) {
     },
     clearOfficeManagerFacility: async (userId: string) => {
       await clearFacilityForUser(userId);
-    }
+    },
+    updateResidentMailPreference,
   };
 
   return (

--- a/frontend/src/services/database.ts
+++ b/frontend/src/services/database.ts
@@ -56,6 +56,14 @@ export async function createVendorUserAndLink(facilityId: string, email: string,
 export async function unlinkVendorFromFacility(vendorUserId: string, facilityId: string) { return rpcCall('unlinkVendorFromFacility', [vendorUserId, facilityId]) }
 export async function linkVendorToFacility(vendorUserId: string, facilityId: string) { return rpcCall('linkVendorToFacility', [vendorUserId, facilityId]) }
 
+// Mail delivery preferences
+export async function updateResidentMailPreference(residentId: string, preference: 'resident_room' | 'reception' | 'other', note?: string) {
+  return rpcCall<Resident>('updateResidentMailPreference', [residentId, preference, note])
+}
+export async function listResidentMailPreferencesByFacility(facilityId: string) {
+  return rpcCall<Array<{ id: string; name: string; mailDeliveryPreference: 'resident_room' | 'reception' | 'other' | null; mailDeliveryNote?: string }>>('listResidentMailPreferencesByFacility', [facilityId])
+}
+
 export async function createSignupInvitationForResident(residentData: { email: string; name: string; facilityId: string; isSelfManaged: boolean; poaEmail?: string; poaName?: string; residentId?: string }, invitedBy: string) { return rpcCall('createSignupInvitationForResident', [residentData, invitedBy]) }
 export async function createSignupInvitation(facilityId: string, email: string, role: 'OM' | 'POA' | 'Resident', invitedBy: string) { return rpcCall<SignupInvitation>('createSignupInvitation', [facilityId, email, role, invitedBy]) }
 export async function sendInvitationEmail(invitation: SignupInvitation, facilityName: string) { return rpcCall<boolean>('sendInvitationEmail', [invitation, facilityName]) }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -83,6 +83,8 @@ export interface Resident {
     wheelchairRepair: boolean;
     miscellaneous: boolean;
   };
+  mailDeliveryPreference?: 'resident_room' | 'reception' | 'other';
+  mailDeliveryNote?: string;
 }
 
 export interface Transaction {

--- a/supabase/add_mail_delivery_preferences.sql
+++ b/supabase/add_mail_delivery_preferences.sql
@@ -1,0 +1,39 @@
+-- Add mail delivery preference enum and columns to residents
+-- Safe to run multiple times
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type t
+    JOIN pg_namespace n ON n.oid = t.typnamespace
+    WHERE t.typname = 'mail_delivery_preference' AND n.nspname = 'public'
+  ) THEN
+    CREATE TYPE public.mail_delivery_preference AS ENUM ('resident_room', 'reception', 'other');
+  END IF;
+END
+$$;
+
+-- Add columns if they don't exist
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns 
+    WHERE table_schema = 'public' AND table_name = 'residents' AND column_name = 'mail_delivery_preference'
+  ) THEN
+    ALTER TABLE public.residents
+      ADD COLUMN mail_delivery_preference public.mail_delivery_preference DEFAULT 'resident_room'::public.mail_delivery_preference;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns 
+    WHERE table_schema = 'public' AND table_name = 'residents' AND column_name = 'mail_delivery_note'
+  ) THEN
+    ALTER TABLE public.residents
+      ADD COLUMN mail_delivery_note text;
+  END IF;
+END
+$$;
+
+-- Optional: set NOT NULL + default for preference if desired (commented out)
+-- ALTER TABLE public.residents ALTER COLUMN mail_delivery_preference SET NOT NULL;
+


### PR DESCRIPTION
Add mail delivery preference options for residents and a corresponding report for office managers.

This feature allows residents to choose their preferred mail delivery method (resident room, reception, or other with a note) via their dashboard, and provides office managers with an overview table and CSV export of all residents' mail preferences.

---
<a href="https://cursor.com/background-agent?bcId=bc-f97a8954-37eb-4752-8425-21f666092822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f97a8954-37eb-4752-8425-21f666092822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

