### PR TITLE
Set default mail delivery preference to null

### DIFF
--- a/frontend/src/components/OMDashboard.tsx
+++ b/frontend/src/components/OMDashboard.tsx
@@ -1090,7 +1090,7 @@ export default function OMDashboard() {
                     const rows = [['Resident', 'Preference', 'Note']].concat(
                       facilityResidents.map(r => [
                         r.name,
-                        r.mailDeliveryPreference || 'resident_room',
+                        r.mailDeliveryPreference ?? '',
                         r.mailDeliveryNote || ''
                       ])
                     );
@@ -1128,7 +1128,13 @@ export default function OMDashboard() {
                         <tr key={r.id} className="hover:bg-gray-50">
                           <td className="px-3 py-2 text-gray-900">{r.name}</td>
                           <td className="px-3 py-2 text-gray-900">
-                            {r.mailDeliveryPreference === 'reception' ? 'Hold at Reception' : r.mailDeliveryPreference === 'other' ? 'Other' : 'Deliver to Resident Room'}
+                            {r.mailDeliveryPreference === 'reception'
+                              ? 'Hold at Reception'
+                              : r.mailDeliveryPreference === 'other'
+                              ? 'Other'
+                              : r.mailDeliveryPreference === 'resident_room'
+                              ? 'Deliver to Resident Room'
+                              : ''}
                           </td>
                           <td className="px-3 py-2 text-gray-900">{r.mailDeliveryNote || '-'}</td>
                         </tr>

--- a/frontend/src/components/POADashboard.tsx
+++ b/frontend/src/components/POADashboard.tsx
@@ -243,7 +243,7 @@ export default function POADashboard() {
               <div>
                 <label className="block text-sm text-gray-600 mb-1">How should the facility deliver your mail?</label>
                 <select
-                  value={linkedResident.mailDeliveryPreference || 'resident_room'}
+                  value={linkedResident.mailDeliveryPreference || ''}
                   onChange={async (e) => {
                     const pref = e.target.value as 'resident_room' | 'reception' | 'other';
                     try {
@@ -256,6 +256,7 @@ export default function POADashboard() {
                   }}
                   className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                 >
+                  <option value="" disabled>Select a preference...</option>
                   <option value="resident_room">Deliver to Resident Room</option>
                   <option value="reception">Hold at Reception</option>
                   <option value="other">Other (specify below)</option>

--- a/supabase/drop_default_mail_delivery_preference.sql
+++ b/supabase/drop_default_mail_delivery_preference.sql
@@ -1,0 +1,4 @@
+-- Drop default for mail_delivery_preference so new rows default to NULL
+ALTER TABLE IF EXISTS public.residents
+  ALTER COLUMN mail_delivery_preference DROP DEFAULT;
+


### PR DESCRIPTION
Remove the default `resident_room` for `mail_delivery_preference` and update dashboards to correctly handle `null` values.

The previous database default and UI logic implicitly set `resident_room` if no preference was specified. This change ensures `null` is the true default, allowing for a clear "no preference" state and requiring explicit selection in the UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-b58910bf-d0ea-4c89-9a6e-be328b056457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b58910bf-d0ea-4c89-9a6e-be328b056457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

