### PR TITLE
Fix resident account not linked status

### DIFF
--- a/frontend/src/contexts/DataContextSupabase.tsx
+++ b/frontend/src/contexts/DataContextSupabase.tsx
@@ -402,7 +402,14 @@ export function DataProvider({ children }: { children: ReactNode }) {
             getCashBoxBalanceDb(linkedResident.facilityId)
           ]);
 
-          setResidents(residentsData);
+          // Ensure the linked resident is present even if facility-wide reads are restricted by RLS
+          const mergedResidents = linkedResident
+            ? (residentsData.some(r => r.id === linkedResident.id)
+                ? residentsData
+                : [linkedResident, ...residentsData])
+            : residentsData;
+
+          setResidents(mergedResidents);
           setTransactions(transactionsData);
           setPreAuthDebits(preAuthDebitsData);
 
@@ -411,8 +418,8 @@ export function DataProvider({ children }: { children: ReactNode }) {
             [linkedResident.facilityId]: cashBoxBalance
           }));
         } else {
-          // Minimal fallback: avoid loading every resident for performance
-          setResidents([]);
+          // Minimal fallback: include the linked resident if available
+          setResidents(linkedResident ? [linkedResident] : []);
         }
       } else {
         // Original logic for Admin and OM users


### PR DESCRIPTION
Fix 'Account Not Linked' message for POA/Resident users by ensuring the linked resident is always present in the `residents` context.

Previously, under Row Level Security (RLS) restrictions, the `residents` context might not include the currently linked resident if facility-wide data reads were limited. This caused the UI to incorrectly display 'Account Not Linked' even when the account was properly linked.

---
<a href="https://cursor.com/background-agent?bcId=bc-1e0b728c-a7dc-47ff-aa34-54e5162c1f52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1e0b728c-a7dc-47ff-aa34-54e5162c1f52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

